### PR TITLE
Update OSDI deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -36,7 +36,7 @@
   year: 2020
   id: osdi2020
   link: https://www.usenix.org/conference/osdi20
-  deadline: '2020-05-12 15:00:00'
+  deadline: '2020-05-27 15:00:00'
   timezone: America/Los_Angeles
   date: November 4-6, 2020
   place: Banff, Alberta, Canada


### PR DESCRIPTION
As per https://www.usenix.org/conference/osdi20/call-for-papers
The deadline has been changed to Wednesday, May 27, 2020, 3:00 pm PDT.